### PR TITLE
Add env-based credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to `.env` and fill in your credentials
+TELEGRAM_API_ID=your_api_id
+TELEGRAM_API_HASH=your_api_hash
+BOT_TOKEN=your_bot_token

--- a/README.md
+++ b/README.md
@@ -9,16 +9,29 @@ So basic script, about 100 code lines, simple to use.
 1. Download and install python 3.10+. [click](https://www.python.org/downloads/release/python-3115/)
 2. Download/clone this repository (folder).
 3. Open terminal and run command like this:
-    
+
     `cd /path/to/this/folder`
 
 4. Install required packages:
 
     `python -m pip install -r requirements.txt`
 
-5. Run script by this command:
+5. Copy `.env.example` to `.env` and add your Telegram credentials.
+
+6. Run the script by this command:
 
     `python main.py`
+
+### Running as a Telegram bot
+
+1. Copy `.env.example` to `.env` and fill in `BOT_TOKEN`,
+   `TELEGRAM_API_ID`, and `TELEGRAM_API_HASH`.
+2. Start the bot with:
+
+    `python bot.py`
+
+The bot understands the `/parse` command. Send `/parse <channel>` and it will
+reply with similar channels.
 
 Enjoy.
 

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,80 @@
+"""Simple Telegram bot integration for the Similar Channel Parser.
+
+This bot accepts the ``/parse`` command with a channel username and
+responds with a list of similar channels.  It reuses the
+``SimilarChannelParser`` class from ``main.py``.
+
+Make sure to provide ``BOT_TOKEN`` in your ``.env`` file.
+"""
+
+import asyncio
+from io import BytesIO
+from typing import List
+
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+)
+
+import config
+from main import SimilarChannelParser
+
+
+parser = SimilarChannelParser()
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Sends a simple greeting and usage hint."""
+    await update.message.reply_text(
+        "Send /parse <channel_username> to get a list of similar channels."
+    )
+
+
+async def parse_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handles the /parse command."""
+    if not context.args:
+        await update.message.reply_text("Usage: /parse <channel_username>")
+        return
+
+    username = context.args[0]
+
+    try:
+        channels = await parser.get_similar_channels(username)
+    except Exception as exc:  # pragma: no cover - network call
+        await update.message.reply_text(f"Error: {exc}")
+        return
+
+    if not channels:
+        await update.message.reply_text("No similar channels found.")
+        return
+
+    text = "\n".join(channels)
+    if len(text) < 4000:
+        await update.message.reply_text(text)
+    else:
+        # If there are many channels, send them as a text file
+        buffer = BytesIO(text.encode("utf-8"))
+        buffer.name = "channels.txt"
+        await update.message.reply_document(buffer)
+
+
+async def main() -> None:
+    """Runs the Telegram bot."""
+    await parser.connect()
+
+    application = ApplicationBuilder().token(config.BOT_TOKEN).build()
+
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("parse", parse_command))
+
+    await application.initialize()
+    await application.start()
+    await application.updater.start_polling()
+    await application.updater.idle()
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    asyncio.run(main())
+

--- a/config.py
+++ b/config.py
@@ -4,8 +4,21 @@ PROXY = None
 # code parameters (don't touch if you don't know what you're doing)
 LINE_FORMAT = "{username}:{participants_count}:{title}"
 SAVING_DIRECTORY = "saved_channels"
-TELEGRAM_API_ID = 2040
-TELEGRAM_API_HASH = "b18441a1ff607e10a989891a5462e627"
+
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent / ".env")
+
+import os
+
+# API credentials should be provided via environment variables
+TELEGRAM_API_ID = int(os.getenv("TELEGRAM_API_ID", "0"))
+TELEGRAM_API_HASH = os.getenv("TELEGRAM_API_HASH", "")
 TELEGRAM_DEVICE_MODEL = "MacBook Air M1"
 TELEGRAM_SYSTEM_VERSION = "macOS 14.4.1"
 TELEGRAM_APP_VERSION = "4.16.8 arm64"
+
+# Telegram Bot token for bot integration
+# Can be set via the .env file
+BOT_TOKEN = os.getenv("BOT_TOKEN", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ telethon==1.35.0
 yarl==1.9.4
 loguru==0.7.2
 pysocks==1.7.1
+python-telegram-bot==20.6
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- load Telegram API credentials from `.env`
- remove real token defaults from config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684145b457008332b25050a311d470bc